### PR TITLE
sedする際にOSX, Linuxを自動判断

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,8 @@ IWNNSERVER_DIR=iwnnserver
 DIC_DEVICE_PATH=/system/bin/dic
 
 ## adb with flags
-function run_adb()
-{
-	$(pwd)/adb $ADB_FLAGS $@
+function run_adb() {
+    $(pwd)/adb $ADB_FLAGS $@
 }
 
 function check_adb_result() {
@@ -93,12 +92,12 @@ if [ -n "`grep \"iWnn\" temp/b2g.sh`" ]; then
   echo "already have iWnn entry in b2g.sh"
 else
   if [ "$(uname)" == "Darwin" ]; then
-      # for FreeBSD-sed (Mac OS X):
-      sed -i '' '2s|^|/system/bin/iWnnServer /data/iwnn \&\
+    # for FreeBSD-sed (Mac OS X):
+    sed -i '' '2s|^|/system/bin/iWnnServer /data/iwnn \&\
     |' "temp/b2g.sh"
   else
-      # for Gnu-sed (Linux):
-      sed -i '2s|^|/system/bin/iWnnServer /data/iwnn \&\n|' "temp/b2g.sh"
+    # for Gnu-sed (Linux):
+    sed -i '2s|^|/system/bin/iWnnServer /data/iwnn \&\n|' "temp/b2g.sh"
   fi
   run_adb push temp/b2g.sh /system/bin/b2g.sh
   run_adb shell chmod 755 /system/bin/b2g.sh

--- a/install.sh
+++ b/install.sh
@@ -92,11 +92,14 @@ run_adb pull /system/bin/b2g.sh temp/b2g.sh
 if [ -n "`grep \"iWnn\" temp/b2g.sh`" ]; then
   echo "already have iWnn entry in b2g.sh"
 else
-  # for Gnu-sed (Linux):
-  #sed -i '2s|^|/system/bin/iWnnServer /data/iwnn \&\n|' "temp/b2g.sh"
-  # for FreeBSD-sed (Mac OS X):
-  sed -i '' '2s|^|/system/bin/iWnnServer /data/iwnn \&\
-|' "temp/b2g.sh"
+  if [ "$(uname)" == "Darwin" ]; then
+      # for FreeBSD-sed (Mac OS X):
+      sed -i '' '2s|^|/system/bin/iWnnServer /data/iwnn \&\
+    |' "temp/b2g.sh"
+  else
+      # for Gnu-sed (Linux):
+      sed -i '2s|^|/system/bin/iWnnServer /data/iwnn \&\n|' "temp/b2g.sh"
+  fi
   run_adb push temp/b2g.sh /system/bin/b2g.sh
   run_adb shell chmod 755 /system/bin/b2g.sh
 fi


### PR DESCRIPTION
OSX、Linuxを自動で判断して `sed` の内容を切り替えるようにしました。
このプルリクエストをマージしないのであれば、READMEでコメントアウトを差し替えるように書いてあると嬉しいなという印象です (私はちょっとハマりました)。

当方Linux環境では動作確認済みです。OSXは手元にないので確認できていません。
`uname` の結果が `"Darwin"` になるかどうかだけ分かればOKです。
